### PR TITLE
Fix Keychain Implementation for Firefox

### DIFF
--- a/keychain/index.html
+++ b/keychain/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Steem/Hive Keychain Dummy Site</title>
+    <title>Steem/Hive Keychain Signing Tool</title>
   </head>
   <body>
 	<script src="main.js"></script>

--- a/keychain/main.js
+++ b/keychain/main.js
@@ -85,6 +85,19 @@ function hive_transfer(urlParams) {
 };
 
 window.addEventListener('load', function () {
+	if (window.hive_keychain || window.steem_keychain) {
+		keychains_ready();
+	} else {
+		var keychain_check = setInterval(function(){
+			if (window.hive_keychain || window.steem_keychain) {
+				clearInterval(keychain_check);
+				keychains_ready();
+			}
+		}, 250);
+	}
+});
+
+function keychains_ready() {
 	const urlParams = new URLSearchParams(window.location.search);
 	const chain = urlParams.get('chain');
 	if (chain === 'steem') {
@@ -96,7 +109,7 @@ window.addEventListener('load', function () {
 			transfer(urlParams);
 		} else if (type === 'sendTokens') {
 			sendTokens(urlParams);
-		};
+		}
 	} else if (chain === 'hive') {
 		const type = urlParams.get('type');
 		console.log(type);
@@ -106,6 +119,6 @@ window.addEventListener('load', function () {
 			hive_transfer(urlParams);
 		} else if (type === 'sendTokens') {
 			hive_sendTokens(urlParams);
-		};
+		}
 	}
-});
+}


### PR DESCRIPTION
Keychain for Firefox (Hive or STEEM) both take a small amount of time before loading into the firefox browser. To enable this to work, I have written a small interval function that checks for Keychain every 250 milliseconds as it usually loads between 250 MS - 1 Second depending on a number of factors.

As a firefox user, it is very annyoing as I have to copy the URL into another browser, removing some of the convenience of this tool.

Thanks!